### PR TITLE
Use `GuzzleHttp\Psr7\parse_query` instead of `parse_str` in the V2 signer

### DIFF
--- a/src/Signature/SignatureV2.php
+++ b/src/Signature/SignatureV2.php
@@ -15,7 +15,7 @@ class SignatureV2 implements SignatureInterface
         RequestInterface $request,
         CredentialsInterface $credentials
     ) {
-        parse_str($request->getBody(), $params);
+        $params = Psr7\parse_query($request->getBody());
         $params['Timestamp'] = gmdate('c');
         $params['SignatureVersion'] = '2';
         $params['SignatureMethod'] = 'HmacSHA256';

--- a/tests/Signature/SignatureV2Test.php
+++ b/tests/Signature/SignatureV2Test.php
@@ -35,6 +35,26 @@ class SignatureV2Test extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, Psr7\str($result));
     }
 
+    public function testCanSignBodyWithStructureShapes()
+    {
+        $_SERVER['aws_time'] = 'Fri, 09 Sep 2011 23:36:00 GMT';
+        $request = new Request(
+            'POST',
+            'http://foo.com',
+            ['Content-Type' => 'application/x-www-form-urlencoded'],
+            'Test=123&Other=456&Nested.1.Name=foo&Nested.1.Value=bar'
+        );
+        $c = new Credentials(self::DEFAULT_KEY, self::DEFAULT_SECRET, 'foo');
+        $sig = new SignatureV2();
+        $result = $sig->signRequest($request, $c);
+
+        $expected = "POST / HTTP/1.1\r\n"
+            . "Host: foo.com\r\n"
+            . "Content-Type: application/x-www-form-urlencoded\r\n\r\n"
+            . "Test=123&Other=456&Nested.1.Name=foo&Nested.1.Value=bar&Timestamp=Fri%2C+09+Sep+2011+23%3A36%3A00+GMT&SignatureVersion=2&SignatureMethod=HmacSHA256&AWSAccessKeyId=AKIDEXAMPLE&SecurityToken=foo&Signature=MbXBpe7leHe6O49B0CU86h%2By0GKFfQ9rBVCNvQWQlB0%3D";
+        $this->assertEquals($expected, Psr7\str($result));
+    }
+
     /**
      * @expectedException \BadMethodCallException
      */


### PR DESCRIPTION
 `parse_str` cannot handle structure shapes. This will resolve #1 
