### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "aws/aws-sdk-php": "^3.18.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8.35",
         "behat/behat": "^3.0"
     }
 }

--- a/tests/Api/BridgeApiProviderTest.php
+++ b/tests/Api/BridgeApiProviderTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Aws\Api;
 
-class BridgeApiProviderTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class BridgeApiProviderTest extends TestCase
 {
     public function testCanGetDefaultProvider()
     {

--- a/tests/AwsCompatibilityClientTest.php
+++ b/tests/AwsCompatibilityClientTest.php
@@ -5,8 +5,9 @@ use Aws\Signature\AnonymousSignature;
 use Aws\Signature\S3SignatureV4;
 use Aws\Signature\SignatureV2;
 use Aws\Signature\SignatureV4;
+use PHPUnit\Framework\TestCase;
 
-class AwsCompatibilityClientTest extends \PHPUnit_Framework_TestCase
+class AwsCompatibilityClientTest extends TestCase
 {
     /**
      * @dataProvider signatureVersionProvider

--- a/tests/Signature/SignatureV2Test.php
+++ b/tests/Signature/SignatureV2Test.php
@@ -6,11 +6,12 @@ require_once __DIR__ . '/sig_hack.php';
 use Aws\Credentials\Credentials;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Signature\SignatureV2
  */
-class SignatureV2Test extends \PHPUnit_Framework_TestCase
+class SignatureV2Test extends TestCase
 {
     const DEFAULT_KEY = 'AKIDEXAMPLE';
     const DEFAULT_SECRET = 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY';


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.