### PR TITLE
fix compatible with Aws\Signature\SignatureInterface::presign

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "classmap": ["build/"]
     },
     "require": {
-        "aws/aws-sdk-php": "^3.18.7"
+        "aws/aws-sdk-php": "^3.105.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/src/Signature/SignatureV2.php
+++ b/src/Signature/SignatureV2.php
@@ -46,7 +46,8 @@ class SignatureV2 implements SignatureInterface
     public function presign(
         RequestInterface $request,
         CredentialsInterface $credentials,
-        $expires
+        $expires,
+        array $options = []
     ) {
         throw new \BadMethodCallException(__METHOD__ . ' not implemented');
     }


### PR DESCRIPTION
The AWS SDK for PHP v3.105.0 adds a parameter to Aws\Signature\SignatureInterface::presign().
It is a fix for its compatibility.

see: https://github.com/aws/aws-sdk-php/commit/60fbcafc3fe7b776bc95581b07f3507b52a222dd#diff-1b6d9fd60837c4a94e4de30d36039482