### PR TITLE
Added support for AWS SDK for PHP 3.199.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "aws/aws-sdk-php": "^3.105.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8.35|^5.4.3",
         "behat/behat": "^3.0"
     }
 }

--- a/src/Signature/SignatureV2.php
+++ b/src/Signature/SignatureV2.php
@@ -15,7 +15,7 @@ class SignatureV2 implements SignatureInterface
         RequestInterface $request,
         CredentialsInterface $credentials
     ) {
-        $params = Psr7\parse_query($request->getBody());
+        $params = Psr7\Query::parse($request->getBody());
         $params['Timestamp'] = gmdate('c');
         $params['SignatureVersion'] = '2';
         $params['SignatureMethod'] = 'HmacSHA256';
@@ -40,7 +40,7 @@ class SignatureV2 implements SignatureInterface
             )
         );
 
-        return $request->withBody(Psr7\stream_for(http_build_query($params)));
+        return $request->withBody(Psr7\Utils::streamFor(http_build_query($params)));
     }
 
     public function presign(

--- a/tests/Signature/SignatureV2Test.php
+++ b/tests/Signature/SignatureV2Test.php
@@ -32,7 +32,7 @@ class SignatureV2Test extends \PHPUnit_Framework_TestCase
             . "Host: foo.com\r\n"
             . "Content-Type: application/x-www-form-urlencoded\r\n\r\n"
             . "Test=123&Other=456&Timestamp=Fri%2C+09+Sep+2011+23%3A36%3A00+GMT&SignatureVersion=2&SignatureMethod=HmacSHA256&AWSAccessKeyId=AKIDEXAMPLE&SecurityToken=foo&Signature=NzQ9b5Kx6qlKj2UIK6QHIrmq5ypogh9PhBHVXKA4RU4%3D";
-        $this->assertEquals($expected, Psr7\str($result));
+        $this->assertEquals($expected, Psr7\Message::toString($result));
     }
 
     public function testCanSignBodyWithStructureShapes()
@@ -52,7 +52,7 @@ class SignatureV2Test extends \PHPUnit_Framework_TestCase
             . "Host: foo.com\r\n"
             . "Content-Type: application/x-www-form-urlencoded\r\n\r\n"
             . "Test=123&Other=456&Nested.1.Name=foo&Nested.1.Value=bar&Timestamp=Fri%2C+09+Sep+2011+23%3A36%3A00+GMT&SignatureVersion=2&SignatureMethod=HmacSHA256&AWSAccessKeyId=AKIDEXAMPLE&SecurityToken=foo&Signature=MbXBpe7leHe6O49B0CU86h%2By0GKFfQ9rBVCNvQWQlB0%3D";
-        $this->assertEquals($expected, Psr7\str($result));
+        $this->assertEquals($expected, Psr7\Message::toString($result));
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*

AWS SDK for PHP 3.199.0 now supports guzzlehttp/psr7 v2.0.0 (https://github.com/aws/aws-sdk-php/pull/2276).

So, this package also works with guzzlehttp/psr7 v2.0.0.