### PR TITLE
Replace deprecated calls to removed Guzzle PSR7 functions

### DIFF
--- a/features/bootstrap/Aws/Test/Integ/MultipartContext.php
+++ b/features/bootstrap/Aws/Test/Integ/MultipartContext.php
@@ -38,7 +38,7 @@ class MultipartContext implements Context, SnippetAcceptingContext
      */
     public function iHaveASeekableReadStream()
     {
-        $this->stream = Psr7\stream_for(Psr7\try_fopen(self::$tempFile, 'r'));
+        $this->stream = Psr7\Utils::streamFor(Psr7\Utils::tryFopen(self::$tempFile, 'r'));
     }
 
     /**

--- a/features/bootstrap/Aws/Test/Integ/S3Context.php
+++ b/features/bootstrap/Aws/Test/Integ/S3Context.php
@@ -148,7 +148,7 @@ class S3Context implements Context, SnippetAcceptingContext
     public function iChangeTheBodyOfThePreSignedRequestToBe($body)
     {
         $this->presignedRequest = $this->presignedRequest
-            ->withBody(Psr7\stream_for($body));
+            ->withBody(Psr7\Utils::streamFor($body));
     }
 
     /**
@@ -157,7 +157,7 @@ class S3Context implements Context, SnippetAcceptingContext
     public function iHaveAnClientAndIHaveAFile()
     {
         $this->s3Client = self::getSdk()->createS3();
-        $this->stream = Psr7\stream_for(Psr7\try_fopen(self::$tempFile, 'r'));
+        $this->stream = Psr7\Utils::streamFor(Psr7\Utils::tryFopen(self::$tempFile, 'r'));
     }
 
     /**

--- a/features/bootstrap/Aws/Test/PerformanceContext.php
+++ b/features/bootstrap/Aws/Test/PerformanceContext.php
@@ -205,7 +205,7 @@ class PerformanceContext implements Context, SnippetAcceptingContext
     public function thenDownloadTheFile()
     {
         $this->addMockResults($this->s3Client, [new Result([
-            'Body' => Psr7\stream_for(Psr7\try_fopen($this->tempFilePath, 'rb')),
+            'Body' => Psr7\Utils::streamFor(Psr7\Utils::tryFopen($this->tempFilePath, 'rb')),
         ])]);
 
         $this->s3Client->getObject([

--- a/src/Signature/SignatureV2.php
+++ b/src/Signature/SignatureV2.php
@@ -15,7 +15,7 @@ class SignatureV2 implements SignatureInterface
         RequestInterface $request,
         CredentialsInterface $credentials
     ) {
-        $params = Psr7\parse_query($request->getBody());
+        $params = Psr7\Query::parse($request->getBody());
         $params['Timestamp'] = gmdate('c');
         $params['SignatureVersion'] = '2';
         $params['SignatureMethod'] = 'HmacSHA256';
@@ -40,7 +40,7 @@ class SignatureV2 implements SignatureInterface
             )
         );
 
-        return $request->withBody(Psr7\stream_for(http_build_query($params)));
+        return $request->withBody(Psr7\Utils::streamFor(http_build_query($params)));
     }
 
     public function presign(

--- a/tests/Signature/SignatureV2Test.php
+++ b/tests/Signature/SignatureV2Test.php
@@ -32,7 +32,7 @@ class SignatureV2Test extends \PHPUnit_Framework_TestCase
             . "Host: foo.com\r\n"
             . "Content-Type: application/x-www-form-urlencoded\r\n\r\n"
             . "Test=123&Other=456&Timestamp=Fri%2C+09+Sep+2011+23%3A36%3A00+GMT&SignatureVersion=2&SignatureMethod=HmacSHA256&AWSAccessKeyId=AKIDEXAMPLE&SecurityToken=foo&Signature=NzQ9b5Kx6qlKj2UIK6QHIrmq5ypogh9PhBHVXKA4RU4%3D";
-        $this->assertEquals($expected, Psr7\str($result));
+        $this->assertEquals($expected, Psr7\Message::toString($result));
     }
 
     public function testCanSignBodyWithStructureShapes()
@@ -52,7 +52,7 @@ class SignatureV2Test extends \PHPUnit_Framework_TestCase
             . "Host: foo.com\r\n"
             . "Content-Type: application/x-www-form-urlencoded\r\n\r\n"
             . "Test=123&Other=456&Nested.1.Name=foo&Nested.1.Value=bar&Timestamp=Fri%2C+09+Sep+2011+23%3A36%3A00+GMT&SignatureVersion=2&SignatureMethod=HmacSHA256&AWSAccessKeyId=AKIDEXAMPLE&SecurityToken=foo&Signature=MbXBpe7leHe6O49B0CU86h%2By0GKFfQ9rBVCNvQWQlB0%3D";
-        $this->assertEquals($expected, Psr7\str($result));
+        $this->assertEquals($expected, Psr7\Message::toString($result));
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In `guzzlehttp/psr7`, functions in the `Guzzle\Psr7` namespace were removed from v2 onwards - https://github.com/guzzle/psr7/blob/2.1.1/CHANGELOG.md#200beta-1---2021-03-21

The deprecation notices suggest using the replacements used in this PR:

* Psr7\parse_query - https://docs.aws.amazon.com/aws-sdk-php/v3/api/function-GuzzleHttp.Psr7.parse_query.html
* Psr7\str - https://docs.aws.amazon.com/aws-sdk-php/v3/api/function-GuzzleHttp.Psr7.str.html
* Psr7\stream_for - https://docs.aws.amazon.com/aws-sdk-php/v3/api/function-GuzzleHttp.Psr7.stream_for.html
* Psr7\try_fopen - https://docs.aws.amazon.com/aws-sdk-php/v3/api/function-GuzzleHttp.Psr7.try_fopen.html

This avoids errors such as the following when using later versions of `guzzlehttp/psr7`:

```
Call to undefined function GuzzleHttp\Psr7\parse_query()
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
